### PR TITLE
Update admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # parhampboc
+
+This repository contains a simple static website served with Express.
+
+## Running Locally
+
+Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+The admin panel is available at `/admin.html`. The default login password is `ilovelife`. You can override it with the `ADMIN_PASSWORD` environment variable.
+

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const bodyParser = require('body-parser');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'admin123';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'ilovelife';
 
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname)));


### PR DESCRIPTION
## Summary
- document how to run the project and mention the admin password in README
- set default admin password to `ilovelife`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a011fd1c88320aafb8c56e4fd90c2