### PR TITLE
Fix update time display on circuit analysis sections

### DIFF
--- a/electrical.html
+++ b/electrical.html
@@ -186,13 +186,13 @@ nav a {
     <!-- Subject: Electric Circuit Analysis I -->
     <div class="skill" data-id="eca1">
       <span class="skill-title" onclick="toggleContent('eca1-content', this)">
-        Electric Circuit Analysis I 
+        Electric Circuit Analysis I
         <span class="chevron">▼</span>
+        <span class="last-updated-inline"></span>
       </span>
       <div class="progress-bar" onclick="toggleContent('eca1-content', this.parentElement.querySelector('.skill-title'))">
         <div class="progress-fill circuit" style="width: 50%;">50%</div>
       </div>
-      <div class="last-updated"></div>
       <div id="eca1-content" class="content-list">
         <ul>
           <li data-id="eca1_mesh_nodal">
@@ -227,7 +227,6 @@ nav a {
       <div class="progress-bar">
         <div class="progress-fill circuit" style="width: 20%;">20%</div>
       </div>
-      <div class="last-updated"></div>
     </div>
 
     <!-- Electronics I -->


### PR DESCRIPTION
## Summary
- show inline last-updated timestamp for Electric Circuit Analysis I
- remove extra last-updated line from Electric Circuit Analysis II

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687b5ffd7aa8832096339c4ec3a4511b